### PR TITLE
Fixes retry loop caused by not incrementing retry counter.

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/AdhocService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/AdhocService.java
@@ -57,7 +57,8 @@ public class AdhocService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during synchronizeTime", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    synchronizeTimeRequest);
         } finally {
             if (conn != null) {
                 conn.close();

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
@@ -111,7 +111,8 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during set special days", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    specialDaysRequest);
         } finally {
             if (conn != null) {
                 conn.close();
@@ -163,7 +164,8 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during set Configuration Object", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    setConfigurationObjectRequest);
         } finally {
             if (conn != null) {
                 conn.close();
@@ -200,7 +202,8 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during setAdministrativeStatus", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    administrativeStatusType);
         } finally {
             if (conn != null) {
                 LOGGER.info("Closing connection with {}", device.getDeviceIdentification());
@@ -269,7 +272,8 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during setActivityCalendar", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    activityCalendar);
         } finally {
             if (conn != null) {
                 LOGGER.info("Closing connection with {}", device.getDeviceIdentification());
@@ -306,7 +310,8 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during setAlarmNotifications", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    alarmNotifications);
         } finally {
             if (conn != null) {
                 conn.close();

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/DlmsApplicationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/DlmsApplicationService.java
@@ -36,7 +36,8 @@ public class DlmsApplicationService {
         final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(messageMetadata.getDomain(),
                 messageMetadata.getDomainVersion(), messageMetadata.getMessageType(),
                 messageMetadata.getCorrelationUid(), messageMetadata.getOrganisationIdentification(),
-                messageMetadata.getDeviceIdentification(), result, osgpException, responseObject);
+                messageMetadata.getDeviceIdentification(), result, osgpException, responseObject,
+                messageMetadata.getRetryCount());
 
         responseMessageSender.send(responseMessage);
     }

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/InstallationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/InstallationService.java
@@ -52,7 +52,8 @@ public class InstallationService extends DlmsApplicationService {
             final TechnicalException ex = new TechnicalException(ComponentType.UNKNOWN,
                     "Unexpected exception while retrieving response message", e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    smartMeteringDevice);
         }
     }
 }

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ManagementService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ManagementService.java
@@ -85,7 +85,8 @@ public class ManagementService extends DlmsApplicationService {
             final TechnicalException ex = new TechnicalException(ComponentType.UNKNOWN,
                     "Unexpected exception while retrieving response message", e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender, null);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    findEventsQueryMessageDataContainer);
         }
     }
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/MonitoringService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/MonitoringService.java
@@ -123,7 +123,8 @@ public class MonitoringService extends DlmsApplicationService {
             LOGGER.error("Unexpected exception during requestActualMeterReads", e);
             final OsgpException ex = this.ensureOsgpException(e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender, null);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    actualMeterReadsRequest);
         } finally {
             if (conn != null) {
                 conn.close();
@@ -155,7 +156,8 @@ public class MonitoringService extends DlmsApplicationService {
             final TechnicalException ex = new TechnicalException(ComponentType.UNKNOWN,
                     "Unexpected exception while retrieving response message", e);
 
-            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender, null);
+            this.sendResponseMessage(messageMetadata, ResponseMessageResultType.NOT_OK, ex, responseMessageSender,
+                    readAlarmRegisterRequest);
         } finally {
             if (conn != null) {
                 conn.close();

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -34,13 +34,13 @@ public class DlmsDevice extends AbstractEntity {
     private String iccId;
 
     @Column
-    private boolean HLS3Active;
+    private boolean hls3Active;
 
     @Column
-    private boolean HLS4Active;
+    private boolean hls4Active;
 
     @Column
-    private boolean HLS5Active;
+    private boolean hls5Active;
 
     @Column
     private String masterKey;
@@ -64,6 +64,12 @@ public class DlmsDevice extends AbstractEntity {
 
     public String getDeviceIdentification() {
         return this.deviceIdentification;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DlmsDevice[deviceId=%s, hls3=%b, hls4=%b, hls5=%b, ipAddress=%s]",
+                this.deviceIdentification, this.hls3Active, this.hls4Active, this.hls5Active, this.ipAddress);
     }
 
     @Override
@@ -107,36 +113,36 @@ public class DlmsDevice extends AbstractEntity {
         this.communicationProvider = communicationProvider;
     }
 
-    public void setICCId(final String value) {
+    public void setIccId(final String value) {
         this.iccId = value;
     }
 
-    public String getICCId() {
+    public String getIccId() {
         return this.iccId;
     }
 
-    public boolean isHLS3Active() {
-        return this.HLS3Active;
+    public boolean isHls3Active() {
+        return this.hls3Active;
     }
 
-    public void setHLS3Active(final boolean hLS3Active) {
-        this.HLS3Active = hLS3Active;
+    public void setHls3Active(final boolean hls3Active) {
+        this.hls3Active = hls3Active;
     }
 
-    public boolean isHLS4Active() {
-        return this.HLS4Active;
+    public boolean isHls4Active() {
+        return this.hls4Active;
     }
 
-    public void setHLS4Active(final boolean hLS4Active) {
-        this.HLS4Active = hLS4Active;
+    public void setHls4Active(final boolean hls4Active) {
+        this.hls4Active = hls4Active;
     }
 
-    public boolean isHLS5Active() {
-        return this.HLS5Active;
+    public boolean isHls5Active() {
+        return this.hls5Active;
     }
 
-    public void setHLS5Active(final boolean hLS5Active) {
-        this.HLS5Active = hLS5Active;
+    public void setHls5Active(final boolean hls5Active) {
+        this.hls5Active = hls5Active;
     }
 
     public String getMasterKey() {

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/DlmsConnectionFactory.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/DlmsConnectionFactory.java
@@ -30,7 +30,7 @@ public class DlmsConnectionFactory {
      */
     public LnClientConnection getConnection(final DlmsDevice device) throws IOException, OperationNotSupportedException {
 
-        if (device.isHLS5Active()) {
+        if (device.isHls5Active()) {
             return this.getHls5Connection(device);
         } else {
             // TODO ADD IMPLEMENTATIONS FOR OTHER SECURITY MODES

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/DlmsDeviceMessageMetadata.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/DlmsDeviceMessageMetadata.java
@@ -19,13 +19,14 @@ public class DlmsDeviceMessageMetadata {
     private String organisationIdentification;
     private String deviceIdentification;
     private String ipAddress;
+    private int retryCount;
 
     @Override
     public String toString() {
         return String
-                .format("DlmsDeviceMessageMetadata[correlationUid=%s, domain=%s, domainVersion=%s, messageType=%s, organisation=%s, device=%s, ipAddress=%s]",
+                .format("DlmsDeviceMessageMetadata[correlationUid=%s, domain=%s, domainVersion=%s, messageType=%s, organisation=%s, device=%s, ipAddress=%s, retryCount=%d]",
                         this.correlationUid, this.domain, this.domainVersion, this.messageType,
-                        this.organisationIdentification, this.deviceIdentification, this.ipAddress);
+                        this.organisationIdentification, this.deviceIdentification, this.ipAddress, this.retryCount);
     }
 
     /**
@@ -42,6 +43,7 @@ public class DlmsDeviceMessageMetadata {
         this.organisationIdentification = message.getStringProperty(Constants.ORGANISATION_IDENTIFICATION);
         this.deviceIdentification = message.getStringProperty(Constants.DEVICE_IDENTIFICATION);
         this.ipAddress = message.getStringProperty(Constants.IP_ADDRESS);
+        this.retryCount = message.getIntProperty(Constants.RETRY_COUNT);
     }
 
     public String getCorrelationUid() {
@@ -98,5 +100,13 @@ public class DlmsDeviceMessageMetadata {
 
     public void setIpAddress(final String ipAddress) {
         this.ipAddress = ipAddress;
+    }
+
+    public int getRetryCount() {
+        return this.retryCount;
+    }
+
+    public void setRetryCount(final int retryCount) {
+        this.retryCount = retryCount;
     }
 }


### PR DESCRIPTION
When the retry mechanism was fixed, it became necessary to send the
initial request data back with a response for failure, to allow
resending it.
This caused issues with response message processors that were not up for
this task, which have been taken care of as well.

Fixes OSGP/Platform#315
