### PR TITLE
Adds challenge length to DlmsDevice.

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -51,6 +51,9 @@ public class DlmsDevice extends AbstractEntity {
     @Column
     private String authenticationKey;
 
+    @Column
+    private Integer challengeLength;
+
     @Transient
     private String ipAddress;
 
@@ -167,6 +170,14 @@ public class DlmsDevice extends AbstractEntity {
 
     public void setAuthenticationKey(final String authenticationKey) {
         this.authenticationKey = authenticationKey;
+    }
+
+    public Integer getChallengeLength() {
+        return this.challengeLength;
+    }
+
+    public void setChallengeLength(final Integer challengeLength) {
+        this.challengeLength = challengeLength;
     }
 
     public void setDeviceIdentification(final String deviceIdentification) {

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/DlmsConnectionFactory.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/DlmsConnectionFactory.java
@@ -48,9 +48,16 @@ public class DlmsConnectionFactory {
             throw new IOException("Unable to get HLS5 connection for device " + device.getDeviceIdentification()
                     + ", because the IP address is not set.");
         }
-        return new TcpConnectionBuilder(InetAddress.getByName(ipAddress))
+        final TcpConnectionBuilder tcpConnectionBuilder = new TcpConnectionBuilder(InetAddress.getByName(ipAddress))
                 .useGmacAuthentication(authenticationKey, encryptionKey).enableEncryption(encryptionKey)
                 .responseTimeout(RESPONSE_TIMEOUT).logicalDeviceAddress(W_PORT_DESTINATION)
-                .clientAccessPoint(W_PORT_SOURCE).buildLnConnection();
+                .clientAccessPoint(W_PORT_SOURCE);
+
+        final Integer challengeLength = device.getChallengeLength();
+        if (challengeLength != null) {
+            tcpConnectionBuilder.challengeLength(challengeLength);
+        }
+
+        return tcpConnectionBuilder.buildLnConnection();
     }
 }

--- a/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V2016.001__Added_device_challenge_length.sql
+++ b/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V2016.001__Added_device_challenge_length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dlms_device ADD COLUMN challenge_length integer;


### PR DESCRIPTION
Communication with Kaifa meters only works for a maximum challenge
lenght of 16 chars. The jDLMS library uses the maximum according to the
specs of 64 chars, unless explicitly overridden. By setting a value for
challenge_length in the dlms_device table, this override will be
configured on the TCP connection.