### PR TITLE
Adds with-list capability check to smart meter message handling.

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/AdhocService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/AdhocService.java
@@ -49,7 +49,7 @@ public class AdhocService extends DlmsApplicationService {
 
             conn = this.dlmsConnectionFactory.getConnection(device);
 
-            this.synchronizeTimeCommandExecutor.execute(conn, null);
+            this.synchronizeTimeCommandExecutor.execute(conn, device, null);
 
             this.sendResponseMessage(messageMetadata, ResponseMessageResultType.OK, null, responseMessageSender);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
@@ -100,7 +100,8 @@ public class ConfigurationService extends DlmsApplicationService {
             final DlmsDevice device = this.domainHelperService.findDlmsDevice(messageMetadata);
             conn = this.dlmsConnectionFactory.getConnection(device);
 
-            final AccessResultCode accessResultCode = this.setSpecialDaysCommandExecutor.execute(conn, specialDays);
+            final AccessResultCode accessResultCode = this.setSpecialDaysCommandExecutor.execute(conn, device,
+                    specialDays);
             if (!AccessResultCode.SUCCESS.equals(accessResultCode)) {
                 throw new ProtocolAdapterException("Set special days reported result is: " + accessResultCode);
             }
@@ -152,7 +153,7 @@ public class ConfigurationService extends DlmsApplicationService {
             final DlmsDevice device = this.domainHelperService.findDlmsDevice(messageMetadata);
             conn = this.dlmsConnectionFactory.getConnection(device);
 
-            final AccessResultCode accessResultCode = this.setConfigurationObjectCommandExecutor.execute(conn,
+            final AccessResultCode accessResultCode = this.setConfigurationObjectCommandExecutor.execute(conn, device,
                     configurationObject);
             if (!AccessResultCode.SUCCESS.equals(accessResultCode)) {
                 throw new ProtocolAdapterException("Set configuration object reported result is: " + accessResultCode);
@@ -187,9 +188,9 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.info("Device for Set Administrative Status is: {}", device);
 
             conn = this.dlmsConnectionFactory.getConnection(device);
-            this.setAdministrativeStatusCommandExecutor.execute(conn, administrativeStatusType);
+            this.setAdministrativeStatusCommandExecutor.execute(conn, device, administrativeStatusType);
 
-            final AccessResultCode accessResultCode = this.setAdministrativeStatusCommandExecutor.execute(conn,
+            final AccessResultCode accessResultCode = this.setAdministrativeStatusCommandExecutor.execute(conn, device,
                     administrativeStatusType);
             if (AccessResultCode.SUCCESS != accessResultCode) {
                 throw new ProtocolAdapterException("AccessResultCode for set administrative status was not SUCCESS: "
@@ -225,7 +226,7 @@ public class ConfigurationService extends DlmsApplicationService {
             conn = this.dlmsConnectionFactory.getConnection(device);
 
             final AdministrativeStatusType administrativeStatusType = this.getAdministrativeStatusCommandExecutor
-                    .execute(conn, null);
+                    .execute(conn, device, null);
 
             this.sendResponseMessage(messageMetadata, ResponseMessageResultType.OK, null, responseMessageSender,
                     administrativeStatusType);
@@ -256,9 +257,10 @@ public class ConfigurationService extends DlmsApplicationService {
             LOGGER.info("Device for Activity Calendar is: {}", device);
 
             conn = this.dlmsConnectionFactory.getConnection(device);
-            this.setActivityCalendarCommandExecutor.execute(conn, activityCalendar);
+            this.setActivityCalendarCommandExecutor.execute(conn, device, activityCalendar);
 
-            final MethodResultCode methodResult = this.setActivityCalendarCommandActivationExecutor.execute(conn, null);
+            final MethodResultCode methodResult = this.setActivityCalendarCommandActivationExecutor.execute(conn,
+                    device, null);
 
             if (!MethodResultCode.SUCCESS.equals(methodResult)) {
                 throw new ProtocolAdapterException("AccessResultCode for set Activity Calendar: " + methodResult);
@@ -297,7 +299,7 @@ public class ConfigurationService extends DlmsApplicationService {
 
             conn = this.dlmsConnectionFactory.getConnection(device);
 
-            final AccessResultCode accessResultCode = this.setAlarmNotificationsCommandExecutor.execute(conn,
+            final AccessResultCode accessResultCode = this.setAlarmNotificationsCommandExecutor.execute(conn, device,
                     alarmNotifications);
             if (AccessResultCode.SUCCESS != accessResultCode) {
                 throw new ProtocolAdapterException("AccessResultCode for set alarm notifications was not SUCCESS: "

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ManagementService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ManagementService.java
@@ -72,7 +72,7 @@ public class ManagementService extends DlmsApplicationService {
                         findEventsQuery.getEventLogCategory().toString(), findEventsQuery.getFrom(),
                         findEventsQuery.getUntil());
 
-                events.addAll(this.retrieveEventsCommandExecutor.execute(conn, findEventsQuery));
+                events.addAll(this.retrieveEventsCommandExecutor.execute(conn, device, findEventsQuery));
             }
 
             final EventMessageDataContainer eventMessageDataContainer = new EventMessageDataContainer(events);

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/MonitoringService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/MonitoringService.java
@@ -76,9 +76,9 @@ public class MonitoringService extends DlmsApplicationService {
 
             Serializable response = null;
             if (periodicMeterReadsQuery.isGas()) {
-                response = this.getPeriodicMeterReadsGasCommandExecutor.execute(conn, periodicMeterReadsQuery);
+                response = this.getPeriodicMeterReadsGasCommandExecutor.execute(conn, device, periodicMeterReadsQuery);
             } else {
-                response = this.getPeriodicMeterReadsCommandExecutor.execute(conn, periodicMeterReadsQuery);
+                response = this.getPeriodicMeterReadsCommandExecutor.execute(conn, device, periodicMeterReadsQuery);
             }
 
             this.sendResponseMessage(messageMetadata, ResponseMessageResultType.OK, null, responseMessageSender,
@@ -111,9 +111,9 @@ public class MonitoringService extends DlmsApplicationService {
 
             Serializable response = null;
             if (actualMeterReadsRequest.isGas()) {
-                response = this.actualMeterReadsGasCommandExecutor.execute(conn, actualMeterReadsRequest);
+                response = this.actualMeterReadsGasCommandExecutor.execute(conn, device, actualMeterReadsRequest);
             } else {
-                response = this.actualMeterReadsCommandExecutor.execute(conn, actualMeterReadsRequest);
+                response = this.actualMeterReadsCommandExecutor.execute(conn, device, actualMeterReadsRequest);
             }
 
             this.sendResponseMessage(messageMetadata, ResponseMessageResultType.OK, null, responseMessageSender,
@@ -145,7 +145,7 @@ public class MonitoringService extends DlmsApplicationService {
 
             conn = this.dlmsConnectionFactory.getConnection(device);
 
-            final AlarmRegister alarmRegister = this.readAlarmRegisterCommandExecutor.execute(conn,
+            final AlarmRegister alarmRegister = this.readAlarmRegisterCommandExecutor.execute(conn, device,
                     readAlarmRegisterRequest);
 
             this.sendResponseMessage(messageMetadata, ResponseMessageResultType.OK, null, responseMessageSender,

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/CommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/CommandExecutor.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.openmuc.jdlms.LnClientConnection;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 
 /**
@@ -24,6 +25,7 @@ import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
  */
 public interface CommandExecutor<T, R> {
 
-    R execute(LnClientConnection conn, T object) throws IOException, TimeoutException, ProtocolAdapterException;
+    R execute(LnClientConnection conn, DlmsDevice device, T object) throws IOException, TimeoutException,
+            ProtocolAdapterException;
 
 }

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetActualMeterReadsCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetActualMeterReadsCommandExecutor.java
@@ -16,6 +16,7 @@ import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,8 +65,9 @@ public class GetActualMeterReadsCommandExecutor implements CommandExecutor<Actua
     private DlmsHelperService dlmsHelperService;
 
     @Override
-    public ActualMeterReads execute(final LnClientConnection conn, final ActualMeterReadsQuery actualMeterReadsQuery)
-            throws IOException, TimeoutException, ProtocolAdapterException {
+    public ActualMeterReads execute(final LnClientConnection conn, final DlmsDevice device,
+            final ActualMeterReadsQuery actualMeterReadsQuery) throws IOException, TimeoutException,
+            ProtocolAdapterException {
 
         if (actualMeterReadsQuery != null && actualMeterReadsQuery.isGas()) {
             throw new IllegalArgumentException("ActualMeterReadsQuery object for energy reads should not be about gas.");
@@ -73,7 +75,7 @@ public class GetActualMeterReadsCommandExecutor implements CommandExecutor<Actua
 
         LOGGER.info("Retrieving actual energy reads");
 
-        final List<GetResult> getResultList = conn.get(ATTRIBUTE_ADDRESSES);
+        final List<GetResult> getResultList = this.dlmsHelperService.getWithList(conn, device, ATTRIBUTE_ADDRESSES);
 
         checkResultList(getResultList);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetActualMeterReadsGasCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetActualMeterReadsGasCommandExecutor.java
@@ -18,6 +18,7 @@ import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +45,9 @@ public class GetActualMeterReadsGasCommandExecutor implements CommandExecutor<Ac
     private DlmsHelperService dlmsHelperService;
 
     @Override
-    public MeterReadsGas execute(final LnClientConnection conn, final ActualMeterReadsQuery actualMeterReadsRequest)
-            throws IOException, TimeoutException, ProtocolAdapterException {
+    public MeterReadsGas execute(final LnClientConnection conn, final DlmsDevice device,
+            final ActualMeterReadsQuery actualMeterReadsRequest) throws IOException, TimeoutException,
+            ProtocolAdapterException {
 
         final ObisCode obisCodeMbusMasterValue = this.masterValueForChannel(actualMeterReadsRequest.getChannel());
 
@@ -59,12 +61,13 @@ public class GetActualMeterReadsGasCommandExecutor implements CommandExecutor<Ac
         final AttributeAddress mbusTime = new AttributeAddress(CLASS_ID_MBUS, obisCodeMbusMasterValue,
                 ATTRIBUTE_ID_TIME);
 
-        final List<GetResult> getResultList = conn.get(mbusValue, mbusTime);
+        final List<GetResult> getResultList = this.dlmsHelperService.getWithList(conn, device, mbusValue, mbusTime);
 
         checkResultList(getResultList);
 
         GetResult getResult = getResultList.get(0);
         AccessResultCode resultCode = getResult.resultCode();
+        this.dlmsHelperService.getWithList(conn, device, mbusValue, mbusTime);
         LOGGER.debug("AccessResultCode: {}", resultCode.name());
         final DataObject value = getResult.resultData();
         LOGGER.debug(this.dlmsHelperService.getDebugInfo(value));

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetAdministrativeStatusCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetAdministrativeStatusCommandExecutor.java
@@ -17,6 +17,7 @@ import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.osgp.adapter.protocol.dlms.application.mapping.ConfigurationMapper;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +39,8 @@ public class GetAdministrativeStatusCommandExecutor implements CommandExecutor<V
     private ConfigurationMapper configurationMapper;
 
     @Override
-    public AdministrativeStatusType execute(final LnClientConnection conn, final Void useless) throws IOException,
-    TimeoutException, ProtocolAdapterException {
+    public AdministrativeStatusType execute(final LnClientConnection conn, final DlmsDevice device, final Void useless)
+            throws IOException, TimeoutException, ProtocolAdapterException {
 
         final AttributeAddress getParameter = new AttributeAddress(CLASS_ID, OBIS_CODE, ATTRIBUTE_ID);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetPeriodicMeterReadsCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetPeriodicMeterReadsCommandExecutor.java
@@ -25,6 +25,7 @@ import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SelectiveAccessDescription;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsQuery
 
 @Component()
 public class GetPeriodicMeterReadsCommandExecutor implements
-CommandExecutor<PeriodicMeterReadsQuery, PeriodicMeterReadsContainer> {
+        CommandExecutor<PeriodicMeterReadsQuery, PeriodicMeterReadsContainer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GetPeriodicMeterReadsCommandExecutor.class);
 
@@ -84,7 +85,7 @@ CommandExecutor<PeriodicMeterReadsQuery, PeriodicMeterReadsContainer> {
     private AmrProfileStatusCodeHelperService amrProfileStatusCodeHelperService;
 
     @Override
-    public PeriodicMeterReadsContainer execute(final LnClientConnection conn,
+    public PeriodicMeterReadsContainer execute(final LnClientConnection conn, final DlmsDevice device,
             final PeriodicMeterReadsQuery periodicMeterReadsRequest) throws IOException, TimeoutException,
             ProtocolAdapterException {
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetPeriodicMeterReadsGasCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetPeriodicMeterReadsGasCommandExecutor.java
@@ -25,6 +25,7 @@ import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SelectiveAccessDescription;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +74,7 @@ public class GetPeriodicMeterReadsGasCommandExecutor implements
     private AmrProfileStatusCodeHelperService amrProfileStatusCodeHelperService;
 
     @Override
-    public PeriodicMeterReadsContainerGas execute(final LnClientConnection conn,
+    public PeriodicMeterReadsContainerGas execute(final LnClientConnection conn, final DlmsDevice device,
             final PeriodicMeterReadsQuery periodicMeterReadsQuery) throws IOException, TimeoutException,
             ProtocolAdapterException {
 
@@ -189,7 +190,8 @@ public class GetPeriodicMeterReadsGasCommandExecutor implements
     }
 
     private void processNextPeriodicMeterReadsForMonthly(final List<PeriodicMeterReadsGas> periodicMeterReads,
-            final List<DataObject> bufferedObjects, final DateTime bufferedDateTime, final int channel) {
+            final List<DataObject> bufferedObjects, final DateTime bufferedDateTime, final int channel)
+            throws ProtocolAdapterException {
 
         // calculate offset from first entry, -1 because MONTHLY has no AMR
         // entry

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ReadAlarmRegisterCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ReadAlarmRegisterCommandExecutor.java
@@ -17,6 +17,7 @@ import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +41,8 @@ public class ReadAlarmRegisterCommandExecutor implements CommandExecutor<ReadAla
     private AlarmHelperService alarmHelperService;
 
     @Override
-    public AlarmRegister execute(final LnClientConnection conn, final ReadAlarmRegisterRequest object)
-            throws IOException, TimeoutException, ProtocolAdapterException {
+    public AlarmRegister execute(final LnClientConnection conn, final DlmsDevice device,
+            final ReadAlarmRegisterRequest object) throws IOException, TimeoutException, ProtocolAdapterException {
 
         return new AlarmRegister(this.retrieveAlarmRegister(conn));
     }

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/RetrieveEventsCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/RetrieveEventsCommandExecutor.java
@@ -23,6 +23,7 @@ import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SelectiveAccessDescription;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.osgp.adapter.protocol.dlms.application.mapping.DataObjectToEventListConverter;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,17 +68,17 @@ public class RetrieveEventsCommandExecutor implements CommandExecutor<FindEvents
     // @formatter:on
 
     @Override
-    public List<Event> execute(final LnClientConnection conn, final FindEventsQuery findEventsQuery)
-            throws IOException, ProtocolAdapterException, TimeoutException {
+    public List<Event> execute(final LnClientConnection conn, final DlmsDevice device,
+            final FindEventsQuery findEventsQuery) throws IOException, ProtocolAdapterException, TimeoutException {
 
         final SelectiveAccessDescription selectiveAccessDescription = this.getSelectiveAccessDescription(
                 findEventsQuery.getFrom(), findEventsQuery.getUntil());
 
-        final AttributeAddress configurationObjectValue = new AttributeAddress(CLASS_ID,
+        final AttributeAddress eventLogBuffer = new AttributeAddress(CLASS_ID,
                 EVENT_LOG_CATEGORY_OBISCODE_MAP.get(findEventsQuery.getEventLogCategory()), ATTRIBUTE_ID,
                 selectiveAccessDescription);
 
-        final List<GetResult> getResultList = conn.get(configurationObjectValue);
+        final List<GetResult> getResultList = conn.get(eventLogBuffer);
 
         if (getResultList.isEmpty()) {
             throw new ProtocolAdapterException("No GetResult received while retrieving event register "

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetActivityCalendarCommandActivationExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetActivityCalendarCommandActivationExecutor.java
@@ -8,6 +8,7 @@ import org.openmuc.jdlms.MethodParameter;
 import org.openmuc.jdlms.MethodResult;
 import org.openmuc.jdlms.MethodResultCode;
 import org.openmuc.jdlms.ObisCode;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -22,7 +23,8 @@ public class SetActivityCalendarCommandActivationExecutor implements CommandExec
     private static final int METHOD_ID_ACTIVATE_PASSIVE_CALENDAR = 1;
 
     @Override
-    public MethodResultCode execute(final LnClientConnection conn, final Void v) throws IOException {
+    public MethodResultCode execute(final LnClientConnection conn, final DlmsDevice device, final Void v)
+            throws IOException {
 
         LOGGER.info("ACTIVATING PASSIVE CALENDAR");
         final MethodParameter method = new MethodParameter(CLASS_ID, OBIS_CODE, METHOD_ID_ACTIVATE_PASSIVE_CALENDAR);

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetActivityCalendarCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetActivityCalendarCommandExecutor.java
@@ -22,6 +22,7 @@ import org.openmuc.jdlms.datatypes.DataObject;
 import org.osgp.adapter.protocol.dlms.application.mapping.DayProfileConverter;
 import org.osgp.adapter.protocol.dlms.application.mapping.SeasonProfileConverter;
 import org.osgp.adapter.protocol.dlms.application.mapping.WeekProfileConverter;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,8 +59,8 @@ public class SetActivityCalendarCommandExecutor implements CommandExecutor<Activ
     private DlmsHelperService dlmsHelperService;
 
     @Override
-    public AccessResultCode execute(final LnClientConnection conn, final ActivityCalendar activityCalendar)
-            throws IOException, ProtocolAdapterException {
+    public AccessResultCode execute(final LnClientConnection conn, final DlmsDevice device,
+            final ActivityCalendar activityCalendar) throws IOException, ProtocolAdapterException {
         LOGGER.debug("SetActivityCalendarCommandExecutor.execute {} called", activityCalendar.getCalendarName());
 
         final SetParameter calendarNameParameter = this.getCalendarNameParameter(activityCalendar);

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetAdministrativeStatusCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetAdministrativeStatusCommandExecutor.java
@@ -17,6 +17,7 @@ import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SetParameter;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.osgp.adapter.protocol.dlms.application.mapping.ConfigurationMapper;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +28,7 @@ import com.alliander.osgp.dto.valueobjects.smartmetering.AdministrativeStatusTyp
 
 @Component()
 public class SetAdministrativeStatusCommandExecutor implements
-        CommandExecutor<AdministrativeStatusType, AccessResultCode> {
+CommandExecutor<AdministrativeStatusType, AccessResultCode> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SetAdministrativeStatusCommandExecutor.class);
 
@@ -39,7 +40,7 @@ public class SetAdministrativeStatusCommandExecutor implements
     private ConfigurationMapper configurationMapper;
 
     @Override
-    public AccessResultCode execute(final LnClientConnection conn,
+    public AccessResultCode execute(final LnClientConnection conn, final DlmsDevice device,
             final AdministrativeStatusType administrativeStatusType) throws IOException, TimeoutException,
             ProtocolAdapterException {
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetAlarmNotificationsCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetAlarmNotificationsCommandExecutor.java
@@ -24,6 +24,7 @@ import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SetParameter;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,8 +95,8 @@ public class SetAlarmNotificationsCommandExecutor implements CommandExecutor<Ala
     }
 
     @Override
-    public AccessResultCode execute(final LnClientConnection conn, final AlarmNotifications alarmNotifications)
-            throws IOException, TimeoutException, ProtocolAdapterException {
+    public AccessResultCode execute(final LnClientConnection conn, final DlmsDevice device,
+            final AlarmNotifications alarmNotifications) throws IOException, TimeoutException, ProtocolAdapterException {
 
         final AlarmNotifications alarmNotificationsOnDevice = this.retrieveCurrentAlarmNotifications(conn);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetConfigurationObjectCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetConfigurationObjectCommandExecutor.java
@@ -22,6 +22,7 @@ import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SetParameter;
 import org.openmuc.jdlms.datatypes.BitString;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +51,9 @@ public class SetConfigurationObjectCommandExecutor implements CommandExecutor<Co
     private DlmsHelperService dlmsHelperService;
 
     @Override
-    public AccessResultCode execute(final LnClientConnection conn, final ConfigurationObject configurationObject)
-            throws IOException, TimeoutException, ProtocolAdapterException {
+    public AccessResultCode execute(final LnClientConnection conn, final DlmsDevice device,
+            final ConfigurationObject configurationObject) throws IOException, TimeoutException,
+            ProtocolAdapterException {
 
         final ConfigurationObject configurationObjectOnDevice = this.retrieveConfigurationObject(conn);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetSpecialDaysCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetSpecialDaysCommandExecutor.java
@@ -17,6 +17,7 @@ import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SetParameter;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -34,8 +35,8 @@ public class SetSpecialDaysCommandExecutor implements CommandExecutor<List<Speci
     private DlmsHelperService dlmsHelperService;
 
     @Override
-    public AccessResultCode execute(final LnClientConnection conn, final List<SpecialDay> specialDays)
-            throws IOException, ProtocolAdapterException {
+    public AccessResultCode execute(final LnClientConnection conn, final DlmsDevice device,
+            final List<SpecialDay> specialDays) throws IOException, ProtocolAdapterException {
 
         final ArrayList<DataObject> specialDayEntries = new ArrayList<DataObject>();
         int i = 0;

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SynchronizeTimeCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SynchronizeTimeCommandExecutor.java
@@ -16,6 +16,7 @@ import org.openmuc.jdlms.LnClientConnection;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SetParameter;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -30,7 +31,8 @@ public class SynchronizeTimeCommandExecutor implements CommandExecutor<DataObjec
     private DlmsHelperService dlmsHelperService;
 
     @Override
-    public AccessResultCode execute(final LnClientConnection conn, final DataObject object) throws IOException {
+    public AccessResultCode execute(final LnClientConnection conn, final DlmsDevice device, final DataObject object)
+            throws IOException {
         final AttributeAddress clockTime = new AttributeAddress(CLASS_ID, OBIS_CODE, ATTRIBUTE_ID);
 
         final DateTime dt = DateTime.now();

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -55,6 +55,9 @@ public class DlmsDevice extends AbstractEntity {
     @Column
     private Integer challengeLength;
 
+    @Column
+    private boolean withListSupported;
+
     @Transient
     private String ipAddress;
 
@@ -155,6 +158,14 @@ public class DlmsDevice extends AbstractEntity {
 
     public void setChallengeLength(final Integer challengeLength) {
         this.challengeLength = challengeLength;
+    }
+
+    public boolean isWithListSupported() {
+        return this.withListSupported;
+    }
+
+    public void setWithListSupported(final boolean withListSupported) {
+        this.withListSupported = withListSupported;
     }
 
     public void setDeviceIdentification(final String deviceIdentification) {

--- a/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V2016.003__Added_device_with_list_supported.sql
+++ b/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V2016.003__Added_device_with_list_supported.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dlms_device ADD COLUMN with_list_supported boolean NOT NULL DEFAULT true;

--- a/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/domain/commands/DlmsHelperServiceTest.java
+++ b/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/domain/commands/DlmsHelperServiceTest.java
@@ -68,7 +68,7 @@ public class DlmsHelperServiceTest {
     }
 
     @Test
-    public void testFromByteArraySummerTime() {
+    public void testFromByteArraySummerTime() throws Exception {
 
         final DateTime dateInSummerTime = this.dlmsHelperService.fromDateTimeValue(this.byteArraySummerTime());
 
@@ -76,7 +76,7 @@ public class DlmsHelperServiceTest {
     }
 
     @Test
-    public void testFromByteArrayWinterTime() {
+    public void testFromByteArrayWinterTime() throws Exception {
 
         final DateTime dateInWinterTime = this.dlmsHelperService.fromDateTimeValue(this.byteArrayWinterTime());
 

--- a/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/integrationtests/domain/commands/ScalerUnitTest.java
+++ b/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/integrationtests/domain/commands/ScalerUnitTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.openmuc.jdlms.LnClientConnection;
 import org.osgp.adapter.protocol.dlms.application.config.ApplicationContext;
 import org.osgp.adapter.protocol.dlms.application.services.DomainHelperService;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionFactory;
 import org.osgp.adapter.protocol.dlms.infra.messaging.DlmsDeviceMessageMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,10 +51,10 @@ public class ScalerUnitTest {
         dlmsDeviceMessageMetadata.setDeviceIdentification("E0004001515495114");
         dlmsDeviceMessageMetadata.setIpAddress("89.200.96.223");
 
-        final LnClientConnection connection = this.dlmsConnectionFactory.getConnection(this.domainHelperService
-                .findDlmsDevice(dlmsDeviceMessageMetadata));
+        final DlmsDevice device = this.domainHelperService.findDlmsDevice(dlmsDeviceMessageMetadata);
+        final LnClientConnection connection = this.dlmsConnectionFactory.getConnection(device);
 
-        final ScalerUnitTestResponse execute = this.commandExecutor.execute(connection, new TestChannelQuery());
+        final ScalerUnitTestResponse execute = this.commandExecutor.execute(connection, device, new TestChannelQuery());
 
         Assert.assertEquals(DlmsUnit.WH, execute.getScalerUnit().getDlmsUnit());
 

--- a/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/integrationtests/domain/commands/TestScalerUnitCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/integrationtests/domain/commands/TestScalerUnitCommandExecutor.java
@@ -15,6 +15,7 @@ import org.openmuc.jdlms.AccessResultCode;
 import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.LnClientConnection;
 import org.osgp.adapter.protocol.dlms.domain.commands.AbstractMeterReadsScalerUnitCommandExecutor;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +28,8 @@ AbstractMeterReadsScalerUnitCommandExecutor<TestChannelQuery, ScalerUnitTestResp
     private static final Logger LOGGER = LoggerFactory.getLogger(TestScalerUnitCommandExecutor.class);
 
     @Override
-    public ScalerUnitTestResponse execute(final LnClientConnection conn, final TestChannelQuery object)
-            throws IOException, TimeoutException, ProtocolAdapterException {
+    public ScalerUnitTestResponse execute(final LnClientConnection conn, final DlmsDevice device,
+            final TestChannelQuery object) throws IOException, TimeoutException, ProtocolAdapterException {
         final List<GetResult> getResultList = conn.get(this.getScalerUnitAttributeAddress(object));
 
         final GetResult getResult = getResultList.get(0);


### PR DESCRIPTION
For devices unable to respond to get requests with-list, multiple get
requests will be issued. For this the command executor interface is
extended with the device as an input parameter. The device can then be
checked for capabilities when jDLMS calls are prepared.

Date time values with unspecified parts were observed as a result to a
call to one of the meters not supporting with-list requests. These are
given some default year/month/day for now, but this may need to be fixed
in some better way.