### PR TITLE
SLIM-532_Remove_unused_methods_from_enums

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
@@ -141,7 +141,7 @@ public class ConfigurationService {
         LOGGER.info(VISUAL_SEPARATOR);
         LOGGER.info("******** Configuration Object: 0-0:94.31.3.255 *******");
         LOGGER.info(VISUAL_SEPARATOR);
-        LOGGER.info("Operation mode:{} ", gprsOperationModeType.value());
+        LOGGER.info("Operation mode:{} ", gprsOperationModeType.name());
         LOGGER.info("Flags:");
 
         for (final ConfigurationFlagDto configurationFlag : configurationFlags.getConfigurationFlag()) {
@@ -205,7 +205,7 @@ public class ConfigurationService {
         final ProtocolMeterInfo protocolMeterInfo = new ProtocolMeterInfo(gMeterInfo.getChannel(),
                 gMeterInfo.getDeviceIdentification(), gMeterDevice.getValidSecurityKey(
                         SecurityKeyType.G_METER_ENCRYPTION).getKey(), gMeterDevice.getValidSecurityKey(
-                                SecurityKeyType.G_METER_MASTER).getKey());
+                        SecurityKeyType.G_METER_MASTER).getKey());
 
         this.setEncryptionKeyExchangeOnGMeterCommandExecutor.execute(conn, device, protocolMeterInfo);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetConfigurationObjectBundleCommandExecutorImpl.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetConfigurationObjectBundleCommandExecutorImpl.java
@@ -25,8 +25,8 @@ import com.alliander.osgp.dto.valueobjects.smartmetering.SetConfigurationObjectR
 
 @Component()
 public class SetConfigurationObjectBundleCommandExecutorImpl extends
-        BundleCommandExecutor<SetConfigurationObjectRequestDataDto, ActionResponseDto> implements
-        SetConfigurationObjectBundleCommandExecutor {
+BundleCommandExecutor<SetConfigurationObjectRequestDataDto, ActionResponseDto> implements
+SetConfigurationObjectBundleCommandExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SetConfigurationObjectBundleCommandExecutorImpl.class);
 
@@ -54,7 +54,7 @@ public class SetConfigurationObjectBundleCommandExecutorImpl extends
         LOGGER.info(VISUAL_SEPARATOR);
         LOGGER.info("******** Configuration Object: 0-0:94.31.3.255 *******");
         LOGGER.info(VISUAL_SEPARATOR);
-        LOGGER.info("Operation mode:{} ", gprsOperationModeType.value());
+        LOGGER.info("Operation mode:{} ", gprsOperationModeType.name());
         LOGGER.info("Flags:");
 
         for (final ConfigurationFlagDto configurationFlag : configurationFlags.getConfigurationFlag()) {


### PR DESCRIPTION
Classes now use name() method, so that value() method could be removed
from enum.