### PR TITLE
SLIM-651 Updates jDLMS version for retest selective access.

### DIFF
--- a/parent-pa-dlms/pom.xml
+++ b/parent-pa-dlms/pom.xml
@@ -82,7 +82,7 @@
     <apache.commons.schema>2.0.3</apache.commons.schema>
     <maven.compiler.plugin.version>3.2</maven.compiler.plugin.version>
     <netty.version>3.9.4.Final</netty.version>
-    <openmuc.jdlms.version>1.1.0</openmuc.jdlms.version>
+    <openmuc.jdlms.version>1.1.1</openmuc.jdlms.version>
     <javax.inject.version>1</javax.inject.version>
     <license.maven.plugin>2.11</license.maven.plugin>
   </properties>


### PR DESCRIPTION
Update the jDLMS dependency version in the POM to the latest release 1.1.1 for retesting selective access.