### PR TITLE
SLIM-612 introduce result status to operations to make errors clear

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-612-introduce-result-status-to-operations
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/BundleService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/BundleService.java
@@ -24,6 +24,7 @@ import com.alliander.osgp.dto.valueobjects.smartmetering.ActionDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ActionRequestDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ActionResponseDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.BundleMessagesRequestDto;
+import com.alliander.osgp.dto.valueobjects.smartmetering.OsgpResultTypeDto;
 
 @Service(value = "dlmsBundleService")
 public class BundleService {
@@ -76,7 +77,7 @@ public class BundleService {
                             executorName, exception);
                     final String responseMessage = executor == null ? "Unable to handle request"
                             : "Error handling request with " + executorName;
-                    actionDto.setResponse(new ActionResponseDto(exception, responseMessage));
+                    actionDto.setResponse(new ActionResponseDto(OsgpResultTypeDto.NOT_OK, exception, responseMessage));
                 }
             }
         }


### PR DESCRIPTION
* Adds NOT OK as result with ActionResponseDtos created when an exception occurred.
* Introduces getAttributeValue in DlmsHelperService making sure an exception is thrown when the result code is not SUCCESS, preventing callers to return error result data as String result.
* Simplifies creation of jDLMS ObisCode by using available bytes in the constructor instead of conversion to unsigned integers to be able to use ints in the constructor.
* Renames some variables to match names from the DLMS blue book for better understanding.