### PR TITLE
SetActivityCalendarCommandActivationExecutor fixed for Kaifa devices

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetActivityCalendarCommandActivationExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetActivityCalendarCommandActivationExecutor.java
@@ -13,6 +13,7 @@ import org.openmuc.jdlms.MethodParameter;
 import org.openmuc.jdlms.MethodResult;
 import org.openmuc.jdlms.MethodResultCode;
 import org.openmuc.jdlms.ObisCode;
+import org.openmuc.jdlms.datatypes.DataObject;
 import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionHolder;
 import org.osgp.adapter.protocol.dlms.exceptions.ConnectionException;
@@ -35,7 +36,8 @@ public class SetActivityCalendarCommandActivationExecutor extends AbstractComman
             throws ProtocolAdapterException {
 
         LOGGER.info("ACTIVATING PASSIVE CALENDAR");
-        final MethodParameter method = new MethodParameter(CLASS_ID, OBIS_CODE, METHOD_ID_ACTIVATE_PASSIVE_CALENDAR);
+        final MethodParameter method = new MethodParameter(CLASS_ID, OBIS_CODE, METHOD_ID_ACTIVATE_PASSIVE_CALENDAR,
+                DataObject.newInteger32Data(0));
 
         conn.getDlmsMessageListener().setDescription(
                 "SetActivityCalendarActivation, call method: " + JdlmsObjectToStringUtil.describeMethod(method));


### PR DESCRIPTION
Updated SetActivityCalendarCommandActivationExecutor MethodParameter with DataObject to meet activate_passive_calendar(data) according blue book.