### PR TITLE
SLIM-1222 Fix end-to-end FirmwareUpdate

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
@@ -25,7 +25,6 @@ import org.osgp.adapter.protocol.dlms.domain.commands.SetEncryptionKeyExchangeOn
 import org.osgp.adapter.protocol.dlms.domain.commands.SetPushSetupAlarmCommandExecutor;
 import org.osgp.adapter.protocol.dlms.domain.commands.SetPushSetupSmsCommandExecutor;
 import org.osgp.adapter.protocol.dlms.domain.commands.SetSpecialDaysCommandExecutor;
-import org.osgp.adapter.protocol.dlms.domain.commands.UpdateFirmwareCommandExecutor;
 import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.domain.entities.SecurityKeyType;
 import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionHolder;
@@ -66,6 +65,9 @@ public class ConfigurationService {
     private DomainHelperService domainHelperService;
 
     @Autowired
+    private FirmwareService firmwareService;
+
+    @Autowired
     private SetSpecialDaysCommandExecutor setSpecialDaysCommandExecutor;
 
     @Autowired
@@ -97,9 +99,6 @@ public class ConfigurationService {
 
     @Autowired
     private ReplaceKeyCommandExecutor replaceKeyCommandExecutor;
-
-    @Autowired
-    private UpdateFirmwareCommandExecutor updateFirmwareCommandExecutor;
 
     @Autowired
     private SetClockConfigurationCommandExecutor setClockConfigurationCommandExecutor;
@@ -306,7 +305,7 @@ public class ConfigurationService {
             final String firmwareIdentifier) throws ProtocolAdapterException {
         LOGGER.info("Updating firmware of device {} to firmware with identifier {}", device, firmwareIdentifier);
 
-        return this.updateFirmwareCommandExecutor.execute(conn, device, firmwareIdentifier);
+        return this.firmwareService.updateFirmware(conn, device, firmwareIdentifier);
     }
 
     public GetConfigurationObjectResponseDto requestGetConfigurationObject(final DlmsConnectionHolder conn,

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessor.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import javax.jms.JMSException;
 import javax.jms.ObjectMessage;
 
+import org.osgp.adapter.protocol.dlms.application.services.ConfigurationService;
 import org.osgp.adapter.protocol.dlms.application.services.FirmwareService;
 import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionHolder;
@@ -36,6 +37,9 @@ import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 public class UpdateFirmwareRequestMessageProcessor extends DeviceRequestMessageProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateFirmwareRequestMessageProcessor.class);
+
+    @Autowired
+    private ConfigurationService configurationService;
 
     @Autowired
     private FirmwareService firmwareService;
@@ -82,7 +86,7 @@ public class UpdateFirmwareRequestMessageProcessor extends DeviceRequestMessageP
         this.assertRequestObjectType(String.class, requestObject);
 
         final String firmwareIdentification = (String) requestObject;
-        return this.firmwareService.updateFirmware(conn, device, firmwareIdentification);
+        return this.configurationService.updateFirmware(conn, device, firmwareIdentification);
     }
 
     private void processUpdateFirmwareRequest(final MessageMetadata messageMetadata,

--- a/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessorTest.java
+++ b/osgp-protocol-adapter-dlms/src/test/java/org/osgp/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessorTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.osgp.adapter.protocol.dlms.application.services.ConfigurationService;
 import org.osgp.adapter.protocol.dlms.application.services.DomainHelperService;
 import org.osgp.adapter.protocol.dlms.application.services.FirmwareService;
 import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
@@ -53,6 +54,9 @@ public class UpdateFirmwareRequestMessageProcessorTest {
 
     @Mock
     private RetryHeaderFactory retryHeaderFactory;
+
+    @Mock
+    private ConfigurationService configurationService;
 
     @Mock
     private FirmwareService firmwareService;
@@ -130,7 +134,7 @@ public class UpdateFirmwareRequestMessageProcessorTest {
         this.processor.processMessage(message);
 
         // Assert
-        verify(this.firmwareService, times(1)).updateFirmware(this.dlmsConnectionHolderMock, this.dlmsDeviceMock,
+        verify(this.configurationService, times(1)).updateFirmware(this.dlmsConnectionHolderMock, this.dlmsDeviceMock,
                 firmwareIdentification);
     }
 


### PR DESCRIPTION
Uses configuration service from message processor

The update firmware request originates from the configuration WSDL.
Therefore originate handling the corresponding message from the
ConfigurationService (this method had become unused). Keep delegating
further processing to the FirmwareService.