### PR TITLE
SLIM-1420 Weaken client-side image-to-activate-ok check

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/UpdateFirmwareCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/UpdateFirmwareCommandExecutor.java
@@ -117,7 +117,6 @@ public class UpdateFirmwareCommandExecutor extends AbstractCommandExecutor<Strin
             transfer.activateImage();
             return this.getFirmwareVersionsCommandExecutor.execute(conn, device, null);
         } else {
-            // Image data is not correct.
             throw new ProtocolAdapterException("An unknown error occurred while updating firmware.");
         }
     }


### PR DESCRIPTION
Updates imageToActivateOk to always return true, as this is an optional
check in the flow of the firmware upgrade process. As long as the device
indicates the image is verified, the code will try to activate it.
A warning is logged if no match is found that can be used if any further
errors occur that need to be analyzed.

Refactors names in the imageToActivateOk check to be more inline with
the names for the matching data as described in the DLMS Blue Book.

Updated the ImageTransfer error message constants to better reflect the
actual conditions that may occur. Included the image identification in
the check, because it seems like other image files may have been
transferred as well that you would not want to look at.

In order to have a consistent DLMS octet-string to String conversion for
the identification bytes of the ImageTransfer the character set is
specified as UTF-8 instead of depending on the default character set in
the environment the code is deployed in.

Removed comment about image data not being correct, as I don't think it
makes the code clearer and might be somewhat misleading if the image is
not verified (as imageToActivateOk always returns true now).