### PR TITLE
Keep connection during waiting so device stays in session for image transfer

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ImageTransfer.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ImageTransfer.java
@@ -298,7 +298,7 @@ class ImageTransfer {
     private void waitForImageInitiation() throws ProtocolAdapterException, ImageTransferException {
         final Future<Integer> newStatus = EXECUTOR_SERVICE.submit(new ImageTransferStatusChangeWatcher(
                 ImageTransferStatus.NOT_INITIATED, this.properties.getInitiationStatusCheckInterval(),
-                this.properties.getInitiationStatusCheckTimeout(), true));
+                this.properties.getInitiationStatusCheckTimeout()));
 
         int status;
         try {


### PR DESCRIPTION
If connection is closed, the transfer image could fail because of a missing connection.