### PR TITLE
Use Jasper Wireless to reconnect after firmware activation

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/DomainHelperService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/DomainHelperService.java
@@ -84,7 +84,7 @@ public class DomainHelperService {
         return dlmsDevice;
     }
 
-    private String getDeviceIpAddressFromSessionProvider(final DlmsDevice dlmsDevice)
+    public String getDeviceIpAddressFromSessionProvider(final DlmsDevice dlmsDevice)
             throws ProtocolAdapterException, FunctionalException {
 
         final SessionProvider sessionProvider = this.sessionProviderService

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ImageTransfer.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ImageTransfer.java
@@ -575,19 +575,19 @@ class ImageTransfer {
 
                 if (this.disconnectWhileWaiting) {
                     // Always return in connected state.
-                    this.connect();
+                    this.reconnect();
                 }
             }
 
             return status;
         }
 
-        private void connect() throws TechnicalException, FunctionalException {
-            ImageTransfer.this.connector.connect();
-        }
-
         private void disconnect() throws IOException {
             ImageTransfer.this.connector.disconnect();
+        }
+        
+        private void reconnect() throws TechnicalException, FunctionalException, ProtocolAdapterException {
+            ImageTransfer.this.connector.reconnect();
         }
     }
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/DlmsConnectionFactory.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/DlmsConnectionFactory.java
@@ -13,6 +13,7 @@ import javax.inject.Provider;
 import javax.naming.OperationNotSupportedException;
 
 import org.openmuc.jdlms.DlmsConnection;
+import org.osgp.adapter.protocol.dlms.application.services.DomainHelperService;
 import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.infra.messaging.DlmsMessageListener;
 import org.slf4j.Logger;
@@ -46,6 +47,9 @@ public class DlmsConnectionFactory {
     @Qualifier("lls0Connector")
     private Provider<DlmsConnector> lls0ConnectorProvider;
 
+    @Autowired
+    private DomainHelperService domainHelperService;
+    
     /**
      * Returns an open connection using the appropriate security settings for
      * the device.
@@ -81,7 +85,7 @@ public class DlmsConnectionFactory {
             throw new FunctionalException(FunctionalExceptionType.UNSUPPORTED_COMMUNICATION_SETTING, ComponentType.PROTOCOL_DLMS);
         }
 
-        final DlmsConnectionHolder holder = new DlmsConnectionHolder(connector, device, dlmsMessageListener);
+        final DlmsConnectionHolder holder = new DlmsConnectionHolder(connector, device, dlmsMessageListener, domainHelperService);
         holder.connect();
         return holder;
     }


### PR DESCRIPTION
When waiting for firmware activation, use Jasper Wireless to reconnect to the DHCP device instead of reusing an obsolete connection.