### PR TITLE
SLIM-1387 Couples M-Bus device based on Short ID

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/CoupleMbusDeviceByChannelCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/CoupleMbusDeviceByChannelCommandExecutor.java
@@ -43,6 +43,15 @@ public class CoupleMbusDeviceByChannelCommandExecutor
         final List<GetResult> resultList = this.coupleMBusDeviceCommandExecutor.getMBusClientAttributeValues(conn,
                 device, requestDto.getChannel());
 
+        /*
+         * Couple M-Bus device by channel is created to couple the M-Bus device
+         * in the platform based on a new M-Bus device discovered alarm for a
+         * particular channel. As such there is no write action to the M-Bus
+         * Client Setup involved, since the platform depends on the attributes
+         * on the gateway device to be able to determine which M-Bus device was
+         * actually involved when the alarm was triggered for the channel from
+         * the request.
+         */
         return new CoupleMbusDeviceByChannelResponseDto(
                 this.coupleMBusDeviceCommandExecutor.makeChannelElementValues(requestDto.getChannel(), resultList));
     }


### PR DESCRIPTION
Couple M-Bus device looked for primary address non zero as first check
if a device was coupled on a channel. For wireless M-Bus devices the
primary address is always zero. If a device is accidentally not coupled
according to OSGP a couple M-Bus device command leads to writing the
Short ID on the next free channel. These changes fix this by focusing
on the M-Bus Short ID when coupling an M-Bus device instead.