### PR TITLE
SLIM-1376: Updates jdlms to version 1.5.1 

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetProfileGenericDataCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetProfileGenericDataCommandExecutor.java
@@ -18,7 +18,6 @@ import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.SelectiveAccessDescription;
-import org.openmuc.jdlms.datatypes.CosemDateTime;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.openmuc.jdlms.interfaceclass.InterfaceClass;
 import org.openmuc.jdlms.interfaceclass.attribute.ClockAttribute;
@@ -36,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.dto.valueobjects.smartmetering.CaptureObjectDefinitionDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.CaptureObjectDto;
+import com.alliander.osgp.dto.valueobjects.smartmetering.CosemDateTimeDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.CosemObjectDefinitionDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.DlmsMeterValueDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.DlmsUnitTypeDto;
@@ -313,7 +313,7 @@ public class GetProfileGenericDataCommandExecutor
     }
 
     private ProfileEntryValueDto makeProfileEntryValueDto(final DataObject dataObject,
-            final ScalerUnitInfo scalerUnitInfo) {
+            final ScalerUnitInfo scalerUnitInfo) throws ProtocolAdapterException {
         if (InterfaceClass.CLOCK.id() == scalerUnitInfo.getClassId()) {
             return this.makeDateProfileEntryValueDto(dataObject);
         } else if (dataObject.isNumber()) {
@@ -325,9 +325,10 @@ public class GetProfileGenericDataCommandExecutor
         }
     }
 
-    private ProfileEntryValueDto makeDateProfileEntryValueDto(final DataObject dataObject) {
-        final CosemDateTime cosemDateTime = CosemDateTime.decode((byte[]) dataObject.getValue());
-        return new ProfileEntryValueDto(cosemDateTime.toCalendar().getTime());
+    private ProfileEntryValueDto makeDateProfileEntryValueDto(final DataObject dataObject)
+            throws ProtocolAdapterException {
+        final CosemDateTimeDto cosemDateTime = this.dlmsHelperService.convertDataObjectToDateTime(dataObject);
+        return new ProfileEntryValueDto(cosemDateTime.asDateTime());
     }
 
     private ProfileEntryValueDto makeNumericProfileEntryValueDto(final DataObject dataObject,

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetProfileGenericDataCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/GetProfileGenericDataCommandExecutor.java
@@ -328,7 +328,7 @@ public class GetProfileGenericDataCommandExecutor
     private ProfileEntryValueDto makeDateProfileEntryValueDto(final DataObject dataObject)
             throws ProtocolAdapterException {
         final CosemDateTimeDto cosemDateTime = this.dlmsHelperService.convertDataObjectToDateTime(dataObject);
-        return new ProfileEntryValueDto(cosemDateTime.asDateTime());
+        return new ProfileEntryValueDto(cosemDateTime.asDateTime().toDate());
     }
 
     private ProfileEntryValueDto makeNumericProfileEntryValueDto(final DataObject dataObject,

--- a/parent-pa-dlms/pom.xml
+++ b/parent-pa-dlms/pom.xml
@@ -81,7 +81,7 @@
     <apache.commons.schema>2.0.3</apache.commons.schema>
     <maven.compiler.plugin.version>3.2</maven.compiler.plugin.version>
     <netty.version>3.9.4.Final</netty.version>
-    <openmuc.jdlms.version>1.4.1</openmuc.jdlms.version>
+    <openmuc.jdlms.version>1.5.1</openmuc.jdlms.version>
     <javax.inject.version>1</javax.inject.version>
     <license.maven.plugin>2.11</license.maven.plugin>
   </properties>


### PR DESCRIPTION
And removes usage of cosemDateTime.toCalendar().