### PR TITLE
SLIM-1475 Keeps track of invocation counter for HLS 5 connection

### DIFF
--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -30,6 +30,8 @@ public class DlmsDevice extends AbstractEntity {
      */
     private static final long serialVersionUID = 3899692163578950343L;
 
+    private static final int KEMA_CODE_LENGTH = 5;
+
     @Column(unique = true, nullable = false, length = 40)
     private String deviceIdentification;
 
@@ -111,6 +113,11 @@ public class DlmsDevice extends AbstractEntity {
 
     public String getDeviceIdentification() {
         return this.deviceIdentification;
+    }
+
+    public long getDeviceId() {
+        final String twelveDigits = this.deviceIdentification.substring(KEMA_CODE_LENGTH);
+        return Long.parseLong(twelveDigits);
     }
 
     @Override
@@ -301,6 +308,14 @@ public class DlmsDevice extends AbstractEntity {
 
     public void setMbusIdentificationNumber(final Long mbusIdentificationNumber) {
         this.mbusIdentificationNumber = mbusIdentificationNumber;
+    }
+
+    public String getManufacturerId() {
+        /*
+         * MbusManufacturerIdentification holds ManufacturerId for non M-Bus
+         * devices.
+         */
+        return this.mbusManufacturerIdentification;
     }
 
     public String getMbusManufacturerIdentification() {

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/SecurityKey.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/entities/SecurityKey.java
@@ -46,6 +46,9 @@ public class SecurityKey extends AbstractEntity {
     @Column(name = "security_key")
     private String key;
 
+    @Column(nullable = true)
+    private Integer invocationCounter;
+
     public SecurityKey() {
         // Default constructor
     }
@@ -113,10 +116,23 @@ public class SecurityKey extends AbstractEntity {
         return this.key;
     }
 
+    public int getInvocationCounter() {
+        return this.invocationCounter == null ? 0 : this.invocationCounter;
+    }
+
+    public void setInvocationCounter(final Integer invocationCounter) {
+        this.invocationCounter = invocationCounter;
+    }
+
     @Override
     public String toString() {
-        return "SecurityKey [securityKeyType=" + this.securityKeyType + ", validFrom=" + this.validFrom + ", validTo="
-                + this.validTo + ", key=" + this.key + "]";
+        final StringBuilder sb = new StringBuilder("SecurityKey[type=");
+        sb.append(this.securityKeyType).append(", validFrom=").append(this.validFrom).append(", validTo=")
+                .append(this.validTo).append(", key=").append(this.key);
+        if (this.invocationCounter != null) {
+            sb.append(", ic=").append(this.invocationCounter);
+        }
+        return sb.append(']').toString();
     }
 
 }

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/SecureDlmsConnector.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/factories/SecureDlmsConnector.java
@@ -17,6 +17,7 @@ import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.domain.entities.SecurityKey;
 import org.osgp.adapter.protocol.dlms.domain.entities.SecurityKeyType;
 import org.osgp.adapter.protocol.dlms.infra.messaging.DlmsMessageListener;
+import org.osgp.adapter.protocol.dlms.infra.messaging.InvocationCountingDlmsMessageListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public abstract class SecureDlmsConnector extends Lls0Connector {
         this.setSecurity(device, tcpConnectionBuilder);
         this.setOptionalValues(device, tcpConnectionBuilder);
 
-        if (device.isInDebugMode()) {
+        if (device.isInDebugMode() || dlmsMessageListener instanceof InvocationCountingDlmsMessageListener) {
             tcpConnectionBuilder.setRawMessageListener(dlmsMessageListener);
         }
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2017 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.osgp.adapter.protocol.dlms.infra.messaging;
+
+import org.osgp.adapter.protocol.dlms.application.services.SecurityKeyService;
+import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.osgp.adapter.protocol.dlms.domain.entities.SecurityKeyType;
+import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionFactory;
+import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.infra.jms.MessageMetadata;
+
+/**
+ * Abstract base class for message processors dealing with optional
+ * DlmsConnection creation and DlmsMessageListener handling.
+ */
+public abstract class DlmsConnectionMessageProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DlmsConnectionMessageProcessor.class);
+
+    @Autowired
+    protected DlmsConnectionFactory dlmsConnectionFactory;
+
+    @Autowired
+    protected DlmsLogItemRequestMessageSender dlmsLogItemRequestMessageSender;
+
+    @Autowired
+    private SecurityKeyService securityKeyService;
+
+    protected DlmsConnectionHolder createConnectionForDevice(final DlmsDevice device,
+            final MessageMetadata messageMetadata) throws OsgpException {
+
+        final InvocationCountingDlmsMessageListener dlmsMessageListener = this
+                .createMessageListenerForDeviceConnection(device, messageMetadata);
+        return this.dlmsConnectionFactory.getConnection(device, dlmsMessageListener);
+    }
+
+    protected InvocationCountingDlmsMessageListener createMessageListenerForDeviceConnection(final DlmsDevice device,
+            final MessageMetadata messageMetadata) {
+        final InvocationCountingDlmsMessageListener dlmsMessageListener;
+        if (device.isInDebugMode()) {
+            dlmsMessageListener = new LoggingDlmsMessageListener(device.getDeviceIdentification(),
+                    this.dlmsLogItemRequestMessageSender);
+            dlmsMessageListener.setMessageMetadata(messageMetadata);
+            dlmsMessageListener.setDescription("Create connection");
+        } else if (device.isHls5Active()) {
+            dlmsMessageListener = new InvocationCountingDlmsMessageListener();
+        } else {
+            dlmsMessageListener = null;
+        }
+        return dlmsMessageListener;
+    }
+
+    protected void doConnectionPostProcessing(final DlmsDevice device, final DlmsConnectionHolder conn) {
+        if (conn == null) {
+            /*
+             * No connection (possible and perfectly valid if an operation was
+             * handled that did not involve device communication), then no
+             * follow-up actions are required.
+             */
+            return;
+        }
+
+        this.closeDlmsConnection(device, conn);
+
+        if (device.isHls5Active()) {
+            this.updateInvocationCounterForEncryptionKey(device, conn);
+        }
+    }
+
+    protected void closeDlmsConnection(final DlmsDevice device, final DlmsConnectionHolder conn) {
+        LOGGER.info("Closing connection with {}", device.getDeviceIdentification());
+        final DlmsMessageListener dlmsMessageListener = conn.getDlmsMessageListener();
+        dlmsMessageListener.setDescription("Close connection");
+        try {
+            conn.close();
+        } catch (final Exception e) {
+            LOGGER.error("Error while closing connection", e);
+        }
+    }
+
+    protected void updateInvocationCounterForEncryptionKey(final DlmsDevice device, final DlmsConnectionHolder conn) {
+
+        if (!(conn.getDlmsMessageListener() instanceof InvocationCountingDlmsMessageListener)) {
+            LOGGER.error(
+                    "updateInvocationCounterForEncryptionKey should only be called for devices with HLS 5 communication with an InvocationCountingDlmsMessageListener - device: {}, hls5: {}, listener: {}",
+                    device.getDeviceIdentification(), device.isHls5Active(),
+                    conn.getDlmsMessageListener() == null ? "null"
+                            : conn.getDlmsMessageListener().getClass().getName());
+            return;
+        }
+
+        final InvocationCountingDlmsMessageListener dlmsMessageListener = (InvocationCountingDlmsMessageListener) conn
+                .getDlmsMessageListener();
+        final int numberOfSentMessages = dlmsMessageListener.getNumberOfSentMessages();
+        this.securityKeyService.incrementInvocationCounter(device.getDeviceIdentification(),
+                SecurityKeyType.E_METER_ENCRYPTION, numberOfSentMessages);
+    }
+}

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/InvocationCountingDlmsMessageListener.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/InvocationCountingDlmsMessageListener.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.osgp.adapter.protocol.dlms.infra.messaging;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.openmuc.jdlms.RawMessageData;
+import org.openmuc.jdlms.RawMessageData.MessageSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alliander.osgp.shared.infra.jms.MessageMetadata;
+
+public class InvocationCountingDlmsMessageListener implements DlmsMessageListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InvocationCountingDlmsMessageListener.class);
+
+    private AtomicInteger numberOfSentMessages = new AtomicInteger(0);
+
+    @Override
+    public void messageCaptured(final RawMessageData rawMessageData) {
+
+        if (MessageSource.CLIENT == rawMessageData.getMessageSource()) {
+            this.numberOfSentMessages.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void setMessageMetadata(final MessageMetadata messageMetadata) {
+        LOGGER.debug("InvocationCountingDlmsMessageListener will be counting for {}", messageMetadata);
+    }
+
+    @Override
+    public void setDescription(final String description) {
+        LOGGER.debug("InvocationCountingDlmsMessageListener will be listening for \"{}\"", description);
+    }
+
+    public int getNumberOfSentMessages() {
+        return this.numberOfSentMessages.get();
+    }
+}

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/LoggingDlmsMessageListener.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/infra/messaging/LoggingDlmsMessageListener.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import com.alliander.osgp.shared.infra.jms.MessageMetadata;
 
-public class LoggingDlmsMessageListener implements DlmsMessageListener {
+public class LoggingDlmsMessageListener extends InvocationCountingDlmsMessageListener implements DlmsMessageListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDlmsMessageListener.class);
 
@@ -40,6 +40,8 @@ public class LoggingDlmsMessageListener implements DlmsMessageListener {
 
     @Override
     public void messageCaptured(final RawMessageData rawMessageData) {
+
+        super.messageCaptured(rawMessageData);
 
         final int sequenceNumber = this.numberOfCapturedMessages.incrementAndGet();
 

--- a/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V20171214093653387__Add_invocation_counter_to_security_key.sql
+++ b/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V20171214093653387__Add_invocation_counter_to_security_key.sql
@@ -1,0 +1,14 @@
+DO $$
+BEGIN
+
+IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema=current_schema
+    AND table_name = 'security_key'
+    AND column_name='invocation_counter'
+) THEN
+    ALTER TABLE ONLY security_key ADD COLUMN invocation_counter INTEGER;
+END IF;
+
+END;
+$$


### PR DESCRIPTION
Changes the code in order to be able to set an invocation counter (IC)
at the start of an HLS 5 connection, and keep track of the IC to prevent
the IC from being reused with the same encryption key. The IC is part of
the initialization vector used with HLS 5 encryption.
The IV should start with the system title (ASCII bytes of three
manufacturer ID chars followed by 5 bytes for the manufacturer device
identification). In order to be able to use a proper system title we
need to know the manufacturer ID for the device.

* Adds invocation counter to SecurityKey so a counter per key can be
  maintained.
* Sets the system title and the frame counter (IC) on the jDLMS TCP
  connection builder for use in the device connection.
* Adds an InvocationCountingDlmsMessageListener to be used as DLMS
  message listener with HLS 5 communication (which is extended by the 
  LoggingDlmsMessageListener used when a device is in debug mode).
* Derives the device ID long value for the system title from the DLMS
  device identification (twelve digits after the 5 character Kema code).
* For now, uses the M-Bus Manufacturer ID as manufacturer ID for the
  e-meter as well (at least until we have a way to properly maintain 
  this property). This should be the first three characters of the
  logical device name (accessible through the P3 public client as the
  value at OBIS code 0-0:42.0.0.255).
* Introduces DlmsConnectionMessageProcessor as abstract base class for
  request/response processors that need to be able to setup HLS 5
  connections with DLMS message listener.
* Refactors message processors for device request, update firmware
  request, OSGP response and get firmware file response in order to use
  a shared implementation of DLMS connection setup and post-processing.