### PR TITLE
SLIM-1626 Make GprsOperationMode and ConfigurationFlags optional for SetConfigurationObject SLIM-1060

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,3 @@
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
 	branch = development
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060
+	branch = development
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060
+

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/application/services/ConfigurationService.java
@@ -40,7 +40,6 @@ import com.alliander.osgp.dto.valueobjects.smartmetering.ActivityCalendarDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.AdministrativeStatusTypeDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.AlarmNotificationsDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ChannelElementValuesDto;
-import com.alliander.osgp.dto.valueobjects.smartmetering.ConfigurationFlagDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ConfigurationFlagsDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ConfigurationObjectDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.DefinableLoadProfileConfigurationDto;
@@ -161,11 +160,12 @@ public class ConfigurationService {
         LOGGER.info(VISUAL_SEPARATOR);
         LOGGER.info("******** Configuration Object: 0-1:94.31.3.255 *******");
         LOGGER.info(VISUAL_SEPARATOR);
-        LOGGER.info("Operation mode:{} ", gprsOperationModeType.name());
-        LOGGER.info("Flags:");
-        for (final ConfigurationFlagDto configurationFlag : configurationFlags.getConfigurationFlag()) {
-            LOGGER.info("Flag : {}, enabled = {}", configurationFlag.getConfigurationFlagType().toString(),
-                    configurationFlag.isEnabled());
+        LOGGER.info("Operation mode: {}",
+                gprsOperationModeType == null ? "not altered by this request" : gprsOperationModeType);
+        if (configurationFlags == null) {
+            LOGGER.info("Flags: none enabled or disabled by this request");
+        } else {
+            LOGGER.info("{}", configurationFlags);
         }
         LOGGER.info(VISUAL_SEPARATOR);
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetConfigurationObjectCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/SetConfigurationObjectCommandExecutor.java
@@ -170,6 +170,9 @@ public class SetConfigurationObjectCommandExecutor
 
     private List<ConfigurationFlagDto> getNewFlags(final ConfigurationObjectDto configurationObject) {
         final List<ConfigurationFlagDto> configurationFlags = new ArrayList<>();
+        if (configurationObject.getConfigurationFlags() == null) {
+            return configurationFlags;
+        }
         for (final ConfigurationFlagDto configurationFlag : configurationObject.getConfigurationFlags()
                 .getConfigurationFlag()) {
             if (!this.isForbidden(configurationFlag.getConfigurationFlagType())) {


### PR DESCRIPTION
The GprsOperationModeType and ConfigurationFlags of the
ConfigurationObject to set have been made optional elements. This
updates the code handling a request to set the configuration object to
deal with omitted parts.