### PR TITLE
SLIM-1775 Returns M-Bus Short IDs upon scan M-Bus channels command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-1775-Read-all-attributes-on-scan-m-bus-channels
 

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/DeviceChannelsHelper.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/DeviceChannelsHelper.java
@@ -9,7 +9,6 @@ package org.osgp.adapter.protocol.dlms.domain.commands;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.GetResult;
@@ -38,8 +37,8 @@ public class DeviceChannelsHelper {
 
     private static final int CLASS_ID = InterfaceClass.MBUS_CLIENT.id();
     /**
-     * The ObisCode for the M-Bus Client Setup exists for a number of channels. DSMR
-     * specifies these M-Bus Client Setup channels as values from 1..4.
+     * The ObisCode for the M-Bus Client Setup exists for a number of channels.
+     * DSMR specifies these M-Bus Client Setup channels as values from 1..4.
      */
     private static final String OBIS_CODE_TEMPLATE = "0.%d.24.1.0.255";
 
@@ -69,35 +68,21 @@ public class DeviceChannelsHelper {
             channelElementValuesList.add(channelElementValues);
             if (requestDto != null && FindMatchingChannelHelper.matches(requestDto, channelElementValues)) {
                 /*
-                 * A complete match for all attributes from the request has been found. Stop
-                 * retrieving M-Bus Client Setup attributes for other channels. Return a list
-                 * returning the values retrieved so far and don't retrieve any additional M-Bus
-                 * Client Setup data from the device.
+                 * A complete match for all attributes from the request has been
+                 * found. Stop retrieving M-Bus Client Setup attributes for
+                 * other channels. Return a list returning the values retrieved
+                 * so far and don't retrieve any additional M-Bus Client Setup
+                 * data from the device.
                  */
                 return channelElementValuesList;
             }
         }
         /*
-         * A complete match for all attributes from the request has not been found. The
-         * best partial match that has no conflicting attribute values, or the first
-         * free channel has to be picked from this list.
+         * A complete match for all attributes from the request has not been
+         * found. The best partial match that has no conflicting attribute
+         * values, or the first free channel has to be picked from this list.
          */
         return channelElementValuesList;
-    }
-
-
-    public List<GetResult> findMbusIdentificationsForDevice(final DlmsConnectionHolder conn,
-            final DlmsDevice device) throws ProtocolAdapterException {
-        final AttributeAddress[] attributeAddresses = IntStream
-                .range(0, NR_OF_CHANNELS)
-                .mapToObj(i -> makeMbusIdentificationAttributeAddress(i + 1))
-                .toArray(AttributeAddress[]::new);
-
-        conn.getDlmsMessageListener().setDescription("DeviceChannelsHelper, retrieve M-Bus identification attributes: "
-                + JdlmsObjectToStringUtil.describeAttributes(attributeAddresses));
-
-        return this.dlmsHelperService.getAndCheck(conn, device, "Retrieve M-Bus identification attributes",
-                attributeAddresses);
     }
 
     protected List<GetResult> getMBusClientAttributeValues(final DlmsConnectionHolder conn, final DlmsDevice device,
@@ -120,12 +105,6 @@ public class DeviceChannelsHelper {
                 "deviceTypeIdentification");
         return new ChannelElementValuesDto(channel, primaryAddress, identificationNumber, manufacturerIdentification,
                 version, deviceTypeIdentification);
-    }
-
-    protected String findIdentificationNumberForChannel(
-            final List<GetResult> identificationNumbers, final short channel)
-            throws ProtocolAdapterException {
-        return this.readIdentificationNumber(identificationNumbers, channel - 1, "identificationNumber");
     }
 
     private String readIdentificationNumber(final List<GetResult> resultList, final int index, final String description)
@@ -168,12 +147,6 @@ public class DeviceChannelsHelper {
         attrAddresses[INDEX_DEVICE_TYPE] = new AttributeAddress(CLASS_ID, obiscode,
                 MbusClientAttribute.DEVICE_TYPE.attributeId());
         return attrAddresses;
-    }
-
-    private AttributeAddress makeMbusIdentificationAttributeAddress(final int channel) {
-        return new AttributeAddress(CLASS_ID,
-                new ObisCode(String.format(OBIS_CODE_TEMPLATE, channel)),
-                MbusClientAttribute.IDENTIFICATION_NUMBER.attributeId());
     }
 
     protected ChannelElementValuesDto writeUpdatedMbus(final DlmsConnectionHolder conn,
@@ -252,9 +225,10 @@ public class DeviceChannelsHelper {
 
     /*
      * @param channelElementValues
-     * 
+     *
      * @return 0-based offset for the channel as opposed to the channels in
-     * ChannelElementValues, where the channels are incremented from FIRST_CHANNEL.
+     * ChannelElementValues, where the channels are incremented from
+     * FIRST_CHANNEL.
      */
     protected short correctFirstChannelOffset(final ChannelElementValuesDto channelElementValues) {
         return (short) (channelElementValues.getChannel() - FIRST_CHANNEL);

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/DeviceChannelsHelper.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/DeviceChannelsHelper.java
@@ -49,10 +49,7 @@ public class DeviceChannelsHelper {
     private static final int INDEX_VERSION = 3;
     private static final int INDEX_DEVICE_TYPE = 4;
 
-    protected static final short FIRST_CHANNEL = 1;
-    protected static final short SECOND_CHANNEL = 2;
-    protected static final short THIRD_CHANNEL = 3;
-    protected static final short FOURTH_CHANNEL = 4;
+    private static final short FIRST_CHANNEL = 1;
     private static final short NR_OF_CHANNELS = 4;
 
     @Autowired

--- a/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ScanMbusChannelsCommandExecutor.java
+++ b/osgp-protocol-adapter-dlms/src/main/java/org/osgp/adapter/protocol/dlms/domain/commands/ScanMbusChannelsCommandExecutor.java
@@ -8,14 +8,16 @@
 
 package org.osgp.adapter.protocol.dlms.domain.commands;
 
-import static org.osgp.adapter.protocol.dlms.domain.commands.DeviceChannelsHelper.FIRST_CHANNEL;
-import static org.osgp.adapter.protocol.dlms.domain.commands.DeviceChannelsHelper.FOURTH_CHANNEL;
-import static org.osgp.adapter.protocol.dlms.domain.commands.DeviceChannelsHelper.SECOND_CHANNEL;
-import static org.osgp.adapter.protocol.dlms.domain.commands.DeviceChannelsHelper.THIRD_CHANNEL;
-
+import java.util.ArrayList;
 import java.util.List;
 
+import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.GetResult;
+import org.openmuc.jdlms.ObisCode;
+import org.openmuc.jdlms.interfaceclass.InterfaceClass;
+import org.openmuc.jdlms.interfaceclass.attribute.MbusClientAttribute;
+import org.osgp.adapter.protocol.dlms.domain.commands.mbus.IdentificationNumber;
+import org.osgp.adapter.protocol.dlms.domain.commands.mbus.ManufacturerId;
 import org.osgp.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.osgp.adapter.protocol.dlms.domain.factories.DlmsConnectionHolder;
 import org.osgp.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
@@ -25,6 +27,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.dto.valueobjects.smartmetering.ActionRequestDto;
+import com.alliander.osgp.dto.valueobjects.smartmetering.MbusChannelShortEquipmentIdentifierDto;
+import com.alliander.osgp.dto.valueobjects.smartmetering.MbusShortEquipmentIdentifierDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ScanMbusChannelsRequestDataDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ScanMbusChannelsResponseDto;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
@@ -32,20 +36,67 @@ import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 @Component
 public class ScanMbusChannelsCommandExecutor extends AbstractCommandExecutor<Void, ScanMbusChannelsResponseDto> {
 
-    @Autowired
-    private DeviceChannelsHelper deviceChannelsHelper;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ScanMbusChannelsCommandExecutor.class);
+
+    private static final int CLASS_ID = InterfaceClass.MBUS_CLIENT.id();
+    /**
+     * IDs of the attributes of the M-Bus Client Setup that make up the Short
+     * ID.
+     *
+     * The order of the IDs in {@link #ATTRIBUTE_IDS_SHORT_ID} should match the
+     * way attributes are used in {@link #makeAttributeAddressesShortIds()} and
+     * {@link #channelShortIdsFromGetResults(List)}.
+     */
+    private static final int[] ATTRIBUTE_IDS_SHORT_ID = new int[] {
+            MbusClientAttribute.IDENTIFICATION_NUMBER.attributeId(), MbusClientAttribute.MANUFACTURER_ID.attributeId(),
+            MbusClientAttribute.VERSION.attributeId(), MbusClientAttribute.DEVICE_TYPE.attributeId() };
+
+    private static final int OBIS_BYTE_A_MBUS_CLIENT_SETUP = 0;
+    private static final int OBIS_BYTE_C_MBUS_CLIENT_SETUP = 24;
+    private static final int OBIS_BYTE_D_MBUS_CLIENT_SETUP = 1;
+    private static final int OBIS_BYTE_E_MBUS_CLIENT_SETUP = 0;
+    private static final int OBIS_BYTE_F_MBUS_CLIENT_SETUP = 255;
+
+    private static final int NUMBER_OF_CHANNELS = 4;
+    private static final int NUMBER_OF_SHORT_ID_ATTRIBUTES_PER_CHANNEL = ATTRIBUTE_IDS_SHORT_ID.length;
+
+    private static final AttributeAddress[] SHORT_ID_ATTRIBUTE_ADDRESSES = makeAttributeAddressesShortIds();
+
+    @Autowired
+    private DlmsHelperService dlmsHelperService;
 
     public ScanMbusChannelsCommandExecutor() {
         super(ScanMbusChannelsRequestDataDto.class);
     }
 
+    private static ObisCode getObisCodeMbusClientSetup(final int channel) {
+        return new ObisCode(OBIS_BYTE_A_MBUS_CLIENT_SETUP, channel, OBIS_BYTE_C_MBUS_CLIENT_SETUP,
+                OBIS_BYTE_D_MBUS_CLIENT_SETUP, OBIS_BYTE_E_MBUS_CLIENT_SETUP, OBIS_BYTE_F_MBUS_CLIENT_SETUP);
+    }
+
+    /**
+     * @see #ATTRIBUTE_IDS_SHORT_ID
+     * @see #channelShortIdsFromGetResults(List)
+     */
+    private static AttributeAddress[] makeAttributeAddressesShortIds() {
+        final AttributeAddress[] shortIdAddresses = new AttributeAddress[NUMBER_OF_CHANNELS
+                * NUMBER_OF_SHORT_ID_ATTRIBUTES_PER_CHANNEL];
+        int index = 0;
+        for (int channel = 1; channel <= NUMBER_OF_CHANNELS; channel++) {
+            final ObisCode obisCode = getObisCodeMbusClientSetup(channel);
+            for (int i = 0; i < NUMBER_OF_SHORT_ID_ATTRIBUTES_PER_CHANNEL; i++) {
+                shortIdAddresses[index++] = new AttributeAddress(CLASS_ID, obisCode, ATTRIBUTE_IDS_SHORT_ID[i]);
+            }
+        }
+        return shortIdAddresses;
+    }
+
     @Override
     public Void fromBundleRequestInput(final ActionRequestDto bundleInput) throws ProtocolAdapterException {
         /*
-         * ScanMbusChannelsRequestDto does not contain any values to pass on, and the
-         * ScanMbusChannelsCommandExecutor takes a Void as input that is ignored.
+         * ScanMbusChannelsRequestDto does not contain any values to pass on,
+         * and the ScanMbusChannelsCommandExecutor takes a Void as input that is
+         * ignored.
          */
         return null;
     }
@@ -53,19 +104,76 @@ public class ScanMbusChannelsCommandExecutor extends AbstractCommandExecutor<Voi
     @Override
     public ScanMbusChannelsResponseDto execute(final DlmsConnectionHolder conn, final DlmsDevice device,
             final Void mbusAttributesDto) throws OsgpException {
+
         LOGGER.debug("retrieving mbus info on e-meter");
-
-        final List<GetResult> mbusIdentifications = this.deviceChannelsHelper
-                .findMbusIdentificationsForDevice(conn, device);
-
-        return new ScanMbusChannelsResponseDto(
-                this.deviceChannelsHelper
-                        .findIdentificationNumberForChannel(mbusIdentifications, FIRST_CHANNEL),
-                this.deviceChannelsHelper
-                        .findIdentificationNumberForChannel(mbusIdentifications, SECOND_CHANNEL),
-                this.deviceChannelsHelper
-                        .findIdentificationNumberForChannel(mbusIdentifications, THIRD_CHANNEL),
-                this.deviceChannelsHelper
-                        .findIdentificationNumberForChannel(mbusIdentifications, FOURTH_CHANNEL));
+        final List<GetResult> mbusShortIdResults = this.dlmsHelperService.getAndCheck(conn, device,
+                "Retrieve M-Bus Short ID attributes", SHORT_ID_ATTRIBUTE_ADDRESSES);
+        final List<MbusChannelShortEquipmentIdentifierDto> channelShortIds = this
+                .channelShortIdsFromGetResults(mbusShortIdResults);
+        return new ScanMbusChannelsResponseDto(channelShortIds);
     }
+
+    /**
+     * @see #ATTRIBUTE_IDS_SHORT_ID
+     * @see #makeAttributeAddressesShortIds()
+     */
+    private List<MbusChannelShortEquipmentIdentifierDto> channelShortIdsFromGetResults(
+            final List<GetResult> mbusShortIdResults) throws ProtocolAdapterException {
+
+        /*
+         * Process attributes in the same order as they were placed in the
+         * attribute addresses used to retrieve the get results.
+         */
+        final List<MbusChannelShortEquipmentIdentifierDto> channelShortIds = new ArrayList<>();
+        int index = 0;
+        for (short channel = 1; channel <= NUMBER_OF_CHANNELS; channel++) {
+            final String identificationNumber = this.determineIdentificationNumber(mbusShortIdResults.get(index++),
+                    channel);
+            final String manufacturerIdentification = this
+                    .determineManufacturerIdentification(mbusShortIdResults.get(index++), channel);
+            final Short versionIdentification = this.determineVersionIdentification(mbusShortIdResults.get(index++),
+                    channel);
+            final Short deviceTypeIdentification = this
+                    .determineDeviceTypeIdentification(mbusShortIdResults.get(index++), channel);
+            final MbusShortEquipmentIdentifierDto shortId = new MbusShortEquipmentIdentifierDto(identificationNumber,
+                    manufacturerIdentification, versionIdentification, deviceTypeIdentification);
+            channelShortIds.add(new MbusChannelShortEquipmentIdentifierDto(channel, shortId));
+        }
+        return channelShortIds;
+    }
+
+    private String determineIdentificationNumber(final GetResult getResult, final short channel)
+            throws ProtocolAdapterException {
+
+        final Long identification = this.dlmsHelperService.readLong(getResult,
+                "Identification number on channel " + channel);
+        if (identification == null) {
+            return null;
+        }
+        return IdentificationNumber.fromIdentification(identification).getLast8Digits();
+    }
+
+    private String determineManufacturerIdentification(final GetResult getResult, final short channel)
+            throws ProtocolAdapterException {
+
+        final Integer manufacturerId = this.dlmsHelperService.readInteger(getResult,
+                "Manufacturer identification on channel " + channel);
+        if (manufacturerId == null) {
+            return null;
+        }
+        return ManufacturerId.fromId(manufacturerId).getIdentification();
+    }
+
+    private Short determineVersionIdentification(final GetResult getResult, final short channel)
+            throws ProtocolAdapterException {
+
+        return this.dlmsHelperService.readShort(getResult, "Version identification on channel " + channel);
+    }
+
+    private Short determineDeviceTypeIdentification(final GetResult getResult, final short channel)
+            throws ProtocolAdapterException {
+
+        return this.dlmsHelperService.readShort(getResult, "Device type identification on channel " + channel);
+    }
+
 }


### PR DESCRIPTION
On Scan M-Bus Channels all attributes identifying the M-Bus device per
channel should be returned. These are represented conform the M-Bus
Short Equipment Identifier (Short ID) attributes (Identification number,
Manufacturer identification, Version identification, Device type
identification).

* Updates the ScanMbusChannelsCommandExecutor to retrieve and return all
  M-Bus Short ID related attributes for all channels, instead of just
  the M-Bus identification numbers.